### PR TITLE
Add screenshot on test errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ Le variabili racchiuse tra `{{` e `}}` vengono sostituite con i valori specifica
 ## Limitazioni
 
 Il parser compreso in `run_test.py` scompone il testo in frasi e riconosce alcune azioni in base al verbo iniziale ("click", "fill", "select", "expect", "go", "wait"). Il target e l'eventuale valore vengono estratti con espressioni regolari. Se una frase non corrisponde a nessuna regola viene riportato un passaggio TODO. È comunque possibile estendere le regole personalizzando `parse_step` e `execute_step`.
+
+## Screenshot in caso di errore
+
+Se durante l'esecuzione di un test avviene un errore, il programma cattura uno screenshot della pagina corrente e lo salva nel file `error_step_<numero>.png` nella cartella da cui viene eseguito lo script.

--- a/run_test.py
+++ b/run_test.py
@@ -167,8 +167,16 @@ def run_test(test_config: dict):
         browser = p.chromium.launch()
         page = browser.new_page()
         page.goto(url)
-        for step in steps:
-            execute_step(step, page)
+        for idx, step in enumerate(steps, start=1):
+            try:
+                execute_step(step, page)
+            except Exception as e:
+                print(f"Error executing step {idx}: {e}")
+                screenshot_path = f"error_step_{idx}.png"
+                page.screenshot(path=screenshot_path)
+                print(f"Screenshot saved to {screenshot_path}")
+                browser.close()
+                raise
         browser.close()
 
 


### PR DESCRIPTION
## Summary
- capture screenshot if a step fails during execution
- document screenshot functionality in README

## Testing
- `python run_test.py example_test.json` *(fails: Host system is missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888a363919c832294963c1c260fe09e