### PR TITLE
Handle target in expect steps

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -145,7 +145,11 @@ def execute_step(step: dict, page):
         return
 
     if action == "expect":
-        expect(page.locator('body')).to_contain_text(step["value"])
+        target = step.get("target")
+        if target:
+            expect(page.get_by_text(target)).to_contain_text(step["value"])
+        else:
+            expect(page.locator('body')).to_contain_text(step["value"])
         return
 
     if action == "goto":


### PR DESCRIPTION
## Summary
- respect element targets when verifying page text

## Testing
- `python -m py_compile run_test.py`
- `python run_test.py example_test.json` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6895af8d187c8322a61c512ef14298b5